### PR TITLE
Refactor the scheduler to use Fibonacci heap and queue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ clean:
 all: clean build
 
 run:
-	./bin/test_generator.out
-	./bin/process_generator.out
+	valgrind ./bin/test_generator.out
+	valgrind ./bin/process_generator.out

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Always start the line with a tab in Makefile, it is its syntax
 
 process_generator_deps = ./src/ds/queue.c ./src/utils.c
-scheduler_deps = ./src/scheduling_algorithms.c ./src/ds/priority_queue.c ./src/utils.c
+scheduler_deps = ./src/scheduling_algorithms.c ./src/ds/queue.c ./src/ds/fib_heap.c ./src/utils.c
 
 build:
 	gcc ./src/process_generator.c ${process_generator_deps} -o ./bin/process_generator.out

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,4 +6,5 @@ WORKDIR /home/synergify
 COPY . /home/synergify/
 
 RUN apt-get update && \
-    apt-get install htop gcc make -y
+    apt-get install htop gcc make -y && \
+    apt-get install valgrind

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,5 +6,4 @@ WORKDIR /home/synergify
 COPY . /home/synergify/
 
 RUN apt-get update && \
-    apt-get install htop gcc make -y && \
-    apt-get install valgrind
+    apt-get install htop gcc make valgrind -y

--- a/src/ds/queue.c
+++ b/src/ds/queue.c
@@ -12,8 +12,8 @@
 typedef struct queue_node_s queue_node_t;
 typedef struct queue_node_s
 {
-	void* data;
-	queue_node_t* next;
+	void *data;
+	queue_node_t *next;
 } queue_node_t;
 
 /**
@@ -60,7 +60,7 @@ queue_t *create_queue()
  */
 bool enqueue(queue_t *my_queue, void *data)
 {
-	queue_node_t* node = malloc(sizeof(queue_node_t));
+	queue_node_t *node = malloc(sizeof(queue_node_t));
 	if (!node)
 	{
 		return false;
@@ -69,9 +69,12 @@ bool enqueue(queue_t *my_queue, void *data)
 	node->data = data;
 	node->next = NULL;
 
-	if (my_queue->tail == NULL) {
+	if (my_queue->tail == NULL)
+	{
 		my_queue->head = node;
-	} else my_queue->tail->next = node;
+	}
+	else
+		my_queue->tail->next = node;
 	my_queue->tail = node;
 	my_queue->size += 1;
 
@@ -86,13 +89,16 @@ bool enqueue(queue_t *my_queue, void *data)
  */
 void *dequeue(queue_t *my_queue)
 {
-	if (!my_queue->head) return NULL;
-	void* data = my_queue->head->data;
-	queue_node_t* next = my_queue->head->next;
+	if (!my_queue->head)
+		return NULL;
+	void *data = my_queue->head->data;
+	queue_node_t *next = my_queue->head->next;
 
 	free(my_queue->head);
 	my_queue->head = next;
 	my_queue->size -= 1;
+	if (my_queue->size == 0)
+		my_queue->tail = NULL;
 	return data;
 }
 
@@ -102,11 +108,12 @@ void *dequeue(queue_t *my_queue)
  *
  * @return A pointer to the process information at the front of the queue, or NULL if the queue is empty
  */
-const void* front(queue_t* my_queue)
+const void *front(queue_t *my_queue)
 {
-	if (!my_queue->head) return NULL;
+	if (!my_queue->head)
+		return NULL;
 
-	return (const void*)(my_queue->head->data);
+	return (const void *)(my_queue->head->data);
 }
 
 /**
@@ -118,4 +125,22 @@ const void* front(queue_t* my_queue)
 bool is_queue_empty(queue_t *my_queue)
 {
 	return my_queue->size == 0;
+}
+
+/**
+ * queue_free - Frees all memory allocated for the queue elements
+ * @param my_queue: A pointer to the queue
+ *
+ * Description: This function iteratively dequeues each element from the queue and frees its memory.
+ */
+void queue_free(queue_t *my_queue)
+{
+	if (!my_queue)
+		return;
+	void *data = dequeue(my_queue);
+	while (data)
+	{
+		free(data);
+		data = dequeue(my_queue);
+	}
 }

--- a/src/ds/queue.c
+++ b/src/ds/queue.c
@@ -29,16 +29,16 @@ typedef struct queue_s
 	queue_node_t *head;
 	queue_node_t *tail;
 	int size;
-} queue;
+} queue_t;
 
 /**
  * create_queue - Creates a new empty process information queue
  *
- * Return: A pointer to the newly created process information queue, or NULL if memory allocation fails
+ * @return A pointer to the newly created process information queue, or NULL if memory allocation fails
  */
-queue *create_queue()
+queue_t *create_queue()
 {
-	queue *my_queue = malloc(sizeof(queue));
+	queue_t *my_queue = malloc(sizeof(queue_t));
 	if (!my_queue)
 	{
 		exit(-1);
@@ -53,12 +53,12 @@ queue *create_queue()
 
 /**
  * enqueue - Enqueues a process into the queue
- * @queue: A pointer to the process information queue
- * @process: A pointer to the process information to be enqueued
+ * @param my_queue: A pointer to the process information queue
+ * @param data: A pointer to the process information to be enqueued
  *
- * Return: true if the process is enqueued successfully, otherwise false
+ * @return true if the process is enqueued successfully, otherwise false
  */
-bool enqueue(queue *my_queue, void *data)
+bool enqueue(queue_t *my_queue, void *data)
 {
 	queue_node_t* node = malloc(sizeof(queue_node_t));
 	if (!node)
@@ -80,11 +80,11 @@ bool enqueue(queue *my_queue, void *data)
 
 /**
  * dequeue - Dequeues a process from the queue
- * @queue: A pointer to the process information queue
+ * @param my_queue: A pointer to the process information queue
  *
- * Return: A pointer to the dequeued process information, or NULL if the queue is empty
+ * @return A pointer to the dequeued process information, or NULL if the queue is empty
  */
-void *dequeue(queue *my_queue)
+void *dequeue(queue_t *my_queue)
 {
 	if (!my_queue->head) return NULL;
 	void* data = my_queue->head->data;
@@ -98,11 +98,11 @@ void *dequeue(queue *my_queue)
 
 /**
  * front - Retrieves the process at the front of the queue without dequeuing it
- * @queue: A pointer to the process information queue
+ * @param my_queue: A pointer to the process information queue
  *
- * Return: A pointer to the process information at the front of the queue, or NULL if the queue is empty
+ * @return A pointer to the process information at the front of the queue, or NULL if the queue is empty
  */
-const void* front(queue* my_queue)
+const void* front(queue_t* my_queue)
 {
 	if (!my_queue->head) return NULL;
 
@@ -111,11 +111,11 @@ const void* front(queue* my_queue)
 
 /**
  * is_queue_empty - Checks if the queue is empty
- * @queue: A pointer to the process information queue
+ * @param my_queue: A pointer to the process information queue
  *
- * Return: true if the queue is empty, otherwise false
+ * @return true if the queue is empty, otherwise false
  */
-bool is_queue_empty(queue *my_queue)
+bool is_queue_empty(queue_t *my_queue)
 {
 	return my_queue->size == 0;
 }

--- a/src/ds/queue.h
+++ b/src/ds/queue.h
@@ -1,45 +1,45 @@
 #pragma once
 /**
- * queue - data structure that represent "first in, first out (FIFO)"   
+ * queue_t - data structure that represent "first in, first out (FIFO)"   
 */
-typedef struct queue_s queue;
+typedef struct queue_s queue_t;
 
 /**
  * create_queue - function that returns a pointer to an initialized queue
  *
- * Return: A pointer to the newly created process information queue, or NULL if memory allocation fails
+ * @return A pointer to the newly created process information queue, or NULL if memory allocation fails
 */
-queue* create_queue();
+queue_t* create_queue();
 
 /**
  * enqueue - function to insert a new element into the queue
- * @queue: the queue to insert into 
- * @process: the process to insert at the end fo the queue
+ * @param my_queue: the queue to insert into 
+ * @param data: the process to insert at the end fo the queue
  *
- * Return: true if the process is enqueued successfully, otherwise false
+ * @return true if the process is enqueued successfully, otherwise false
 */
-bool enqueue(queue* my_queue, void* data);
+bool enqueue(queue_t* my_queue, void* data);
 
 /**
  * dequeue - function to remove the element at the head of the queue
- * @queue: the queue from which the process would be removed
+ * @param my_queue: the queue from which the process would be removed
  * 
  * Return: the process that has been dequeued
 */
-void* dequeue(queue* my_queue);
+void* dequeue(queue_t* my_queue);
 
 /**
  * front - function that returns a copy of the first element of the queue without removing it
- * @queue: the queue from which the first element will be copied
+ * @param my_queue: the queue from which the first element will be copied
  * 
- * Return: a pointer of the copy of the first element
+ * @return a pointer of the copy of the first element
 */
-const void* front(queue* my_queue);
+const void* front(queue_t* my_queue);
 
 /**
  * is_queue_empty - check if the queue is empty
- * @queue: the queue on which the check would be performed
+ * @param my_queue: the queue on which the check would be performed
  * 
- * Return: a boolean that indicated the result of the check
+ * @return a boolean that indicated the result of the check
 */
-bool is_queue_empty(queue* my_queue);
+bool is_queue_empty(queue_t* my_queue);

--- a/src/ds/queue.h
+++ b/src/ds/queue.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <stdbool.h>
+
 /**
  * queue_t - data structure that represent "first in, first out (FIFO)"   
 */
@@ -43,3 +45,11 @@ const void* front(queue_t* my_queue);
  * @return a boolean that indicated the result of the check
 */
 bool is_queue_empty(queue_t* my_queue);
+
+/**
+ * queue_free - Frees all memory allocated for the queue elements
+ * @param my_queue: A pointer to the queue
+ *
+ * Description: This function iteratively dequeues each element from the queue and frees its memory.
+ */
+void queue_free(queue_t *my_queue);

--- a/src/header.h
+++ b/src/header.h
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <string.h>
 #include <stdarg.h>
-#include "ds/priority_queue.h"
 
 #define PATH_SIZE 256
 
@@ -162,68 +161,33 @@ typedef struct rprocess_s
 } rprocess_t;
 
 /**
- * initializeProcesses - Initializes processes based on the number of processes to be created.
- *
- * @param head: Pointer to the pointer to the head of the priority queue.
- * @param num_of_processes: Number of processes to be initialized.
- *
- * Description: On a received signal from the generator, initializes processes, forks them, 
- *              and adds them to the ready queue.
- */
-void initializeProcesses(int signum);
-
-/**
- * terminateRunningProcess - Terminates the currently running process
- *
- * @param signum: The signal number that triggered the termination.
- *
- * Description: Waits for the currently running process to terminate and then removes
- *              it from the ready queue.
- */
-void terminateRunningProcess(int signum);
-
-/**
- * noMoreProcesses - Informs the scheduler that no more processes would be sent.
- */
-void noMoreProcesses(int signum);
-
-
-/**
- * addToReadyQueue - Adds a process to the ready queue based on the scheduling algorithm.
- *
- * @param process: Pointer to the process to be added.
- *
- * Description: Adds a process to the ready queue based on the selected scheduling algorithm.
- */
-void addToReadyQueue(PCB *process);
-
-/**
  * scheduleSRTN - Runs the shortest remaining time first algorithm
  *
- * @param head: Pointer to the pointer to the head of the priority queue.
+ * @param head: Pointer to the ready_queue.
  *
  * Description: Checks if their is a running process and decrease its priority
  *              as it indicates its remaining running time.
  */
-void scheduleRR(pqueue_t **head);
+void scheduleRR(void *head);
 
 /**
  * scheduleSRTN - Runs the shortest remaining time first algorithm
  *
- * @param head: Pointer to the pointer to the head of the priority queue.
+ * @param head: Pointer to the ready_queue.
  *
- * Description: Checks if their is a running process and decrease its priority
+ * Description: Checks if their is a running process and decrements its key
  *              as it indicates its remaining running time.
  */
-void scheduleSRTN(pqueue_t **head);
+void scheduleSRTN(void *head);
 
 /**
  * scheduleHPF - Schedule a process using the Highest Priority First (HPF) algorithm (non-preemptive).
- * @param head: Pointer to the head of the priority queue.
+ * @param head: Pointer to the ready_queue.
  *
- * Description: Useless for now
+ * Description: Checks if their is a running process and decrease its key
+ *              as it indicates its priority.
  */
-void scheduleHPF(pqueue_t **head);
+void scheduleHPF(void *head);
 
 /**
  * contentSwitch - Switches context to the next process
@@ -236,4 +200,4 @@ void scheduleHPF(pqueue_t **head);
  *              If the new front process is -1, it means there's no new front process to switch to.
  */
 void contentSwitch(PCB *new_front, PCB *old_front, int currentTime, FILE *file);
-void printQueue(pqueue_t** head);
+//void printQueue(pqueue_t** head);

--- a/src/process.c
+++ b/src/process.c
@@ -10,19 +10,22 @@ int prev_time;
 ///==============================
 // functions
 void allocateCPU(int);
+void pauseProcess(int);
 ///==============================
 
-int main(int argc, char * argv[])
+int main(int argc, char *argv[])
 {
     ///==============================
     // bind signal handlers
     signal(SIGCONT, allocateCPU);
+    signal(SIGUSR1, pauseProcess);
     ///==============================
 
     // Sleep till the scheduler wakes me up
     pause();
-  
-    if (argc != 5) {
+
+    if (argc != 5)
+    {
         perror("Use: ./process <id> <arrival_time> <running_time> <priority>");
         exit(EXIT_FAILURE);
     }
@@ -31,14 +34,15 @@ int main(int argc, char * argv[])
     initClk();
     prev_time = getClk();
 
-    //TODO it needs to get the remaining time from somewhere
+    // TODO it needs to get the remaining time from somewhere
     remaining_time = atoi(argv[3]);
 
-    //printf("Process %d awakened\n", getpid());
+    // printf("Process %d awakened\n", getpid());
     printf("process id: %s\n", argv[1]);
     while (remaining_time > 0)
     {
-        if (getClk() == prev_time) continue;
+        if (getClk() == prev_time)
+            continue;
         printf("Process.c #%s decremented to %d\n", argv[1], remaining_time);
         remaining_time -= 1;
         prev_time = getClk();
@@ -55,4 +59,9 @@ void allocateCPU(int sig_num)
 {
     // allocate the CPU
     return;
+}
+
+void pauseProcess(int sig_num)
+{
+    pause();
 }

--- a/src/process_generator.c
+++ b/src/process_generator.c
@@ -16,7 +16,7 @@ const char *clk_file_name = "clk.out\0";
 ///==============================
 // functions
 void clearResources(int);
-void read_input_file(queue *);
+void read_input_file(queue_t *);
 void childLost(int);
 void get_scheduling_algo(int *algorithm_choosen, int *quantum_time);
 int start_program(const char *const file_name, int n, ...);
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 {
     ///==============================
     // data
-    queue *processes_queue = create_queue();
+    queue_t *processes_queue = create_queue();
     ///==============================
 
     ///==============================
@@ -103,7 +103,7 @@ void clearResources(int signum)
 /**
  * read_input_file - to read the processes and their parameters from a text file
  */
-void read_input_file(queue *processes_queue)
+void read_input_file(queue_t *processes_queue)
 {
     FILE *input_file;
     char file_path[PATH_SIZE];
@@ -123,7 +123,7 @@ void read_input_file(queue *processes_queue)
         process_info_t *process = malloc(sizeof(process_info_t));
         sscanf(buffer, "%d %d %d %d", &(process->id),
                &(process->arrival), &(process->runtime), &(process->priority));
-        enqueue(processes_queue, process);
+        enqueue(processes_queue, (void *)process);
     }
     fclose(input_file);
 }

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -1,5 +1,7 @@
 #include "clk.h"
 #include "header.h"
+#include "ds/fib_heap.h"
+#include "ds/queue.h"
 #include <math.h>
 /**
  * getSchedulerConfigInstance - Function to get the singleton instance of SchedulerConfig.
@@ -18,8 +20,8 @@ SchedulerConfig *getSchedulerConfigInstance()
 }
 
 // To be accessed by signal handlers
-pqueue_t **ready_queue, **queue;
-void generateProcesses();
+void *ready_queue = NULL;
+queue_t *queue = NULL;
 bool endScheduler = false;
 
 float total_waiting_time = 0;             // sum of waiting times
@@ -31,26 +33,24 @@ int idx = 0;                              // index of the wta_values array
 int waste_time = 0;                       // cpu wasted time
 
 PCB *running_process = NULL;
-FILE *logFile;
-float calculate_std_wta()
-{
-    float mean = total_weighted_turnaround_time / total_processes;
-    float sum = 0.0;
-    for (int i = 0; i < total_processes; i++)
-    {
-        sum += pow(wta_values[i] - mean, 2);
-    }
-    float variance = sum / total_processes;
-    return sqrt(variance);
-}
+FILE *logFile, *perf;
 
-void addPref(FILE *file)
-{
-    fprintf(file, "CPU utilization = %.2f%%\n", (float)((total_running_time) / (float)getClk()) * 100.0);
-    fprintf(file, "Avg WTA = %.2f\n", total_weighted_turnaround_time / total_processes);
-    fprintf(file, "Avg Waiting = %.2f\n", total_waiting_time / total_processes);
-    fprintf(file, "STD WTA = %.2f\n", calculate_std_wta());
-}
+//================================= SIGNAL HANDLERS =================================//
+static void initializeProcesses(int signum);
+static void terminateRunningProcess(int signum);
+static void noMoreProcesses(int signum);
+static void clearResources(int signum);
+//=============================== SCHEDULER FUNCTIONS ===============================//
+static void *allocateDataStructure(scheduling_algo selected_algo);
+static PCB *getRunningProcess(scheduling_algo selected_algo);
+static PCB *popRunningProcess(scheduling_algo selected_algo);
+static short is_running_queue_empty(scheduling_algo selected_algo);
+static void generateProcesses();
+static void addToReadyQueue(PCB *process);
+//==================================== LOG DATA =====================================//
+static float calculate_std_wta();
+static void addPref(FILE *file);
+static void addFinishLog(FILE *file, int currentTime, int processId, char *state, int arrivalTime, int totalRuntime, int waitingTime, int TA, float WTA);
 
 int main(int argc, char *argv[])
 {
@@ -61,19 +61,19 @@ int main(int argc, char *argv[])
     }
 
     // Open file for writing
-    logFile = fopen("schedular.log", "w");
-    FILE *perf = fopen("scheduler.perf", "w");
+    logFile = fopen("scheduler.log", "w");
+    perf = fopen("scheduler.perf", "w");
 
     // Check if the file was opened successfully
     if (logFile == NULL)
     {
-        printf("Error opening schedular.logFile!\n");
+        printf("Error opening scheduler.log!\n");
         return 1;
     }
     // Check if the file was opened successfully
     if (perf == NULL)
     {
-        printf("Error opening schedular.perf!\n");
+        printf("Error opening scheduler.perf!\n");
         return 1;
     }
 
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
     signal(SIGUSR1, initializeProcesses);
     signal(SIGCHLD, terminateRunningProcess);
     signal(SIGUSR2, noMoreProcesses);
+    signal(SIGINT, clearResources);
 
     // Get instance of scheduler configuration and set it
     SchedulerConfig *schedulerConfig = getSchedulerConfigInstance();
@@ -91,15 +92,14 @@ int main(int argc, char *argv[])
     schedulerConfig->curr_quantum = schedulerConfig->quantum;
 
     // Array of scheduling functions corresponding to each algorithm
-    void (*scheduleFunction[])(pqueue_t **) = {scheduleHPF, scheduleSRTN, scheduleRR};
+    void (*scheduleFunction[])(void *) = {scheduleHPF, scheduleSRTN, scheduleRR};
 
     int selectedAlgorithmIndex = schedulerConfig->selected_algorithm - 1;
     size_t prev_time = -1;
 
-    ready_queue = malloc(sizeof(pqueue_t *));
-    (*ready_queue) = NULL;
-    queue = malloc(sizeof(pqueue_t *));
-    (*queue) = NULL;
+    // Allocate the data structure depending on the selected algorithm
+    ready_queue = allocateDataStructure(schedulerConfig->selected_algorithm);
+    queue = create_queue();
 
     initClk();
 
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
         int curr_time = getClk();
         // Handle context switching if the queue front changed
         generateProcesses();
-        PCB *front_process = (*ready_queue == NULL ? NULL : ((PCB *)((*ready_queue)->process)));
+        PCB *front_process = getRunningProcess(schedulerConfig->selected_algorithm);
         if (((running_process != NULL) != (front_process != NULL)) || (running_process && running_process->fork_id != front_process->fork_id))
         {
             printf("Context Switching\n");
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
             scheduleFunction[selectedAlgorithmIndex](ready_queue);
         }
 
-        if ((*ready_queue) == NULL && (*queue) == NULL && endScheduler)
+        if (is_running_queue_empty(schedulerConfig->selected_algorithm) && is_queue_empty(queue) && endScheduler)
         {
             break;
         }
@@ -136,24 +136,22 @@ int main(int argc, char *argv[])
     printf("Generating Output files!!!!\n");
     addPref(perf);
 
-    fclose(logFile);
-    fclose(perf);
+    clearResources(0);
 
     // Upon termination release the clock resources.
     destroyClk(false);
     return 0;
 }
 
+//================================= SIGNAL HANDLERS =================================//
+
 /**
  * initializeProcesses - Initializes processes based on the number of processes to be created.
- *
- * @param head: Pointer to the pointer to the head of the priority queue.
- * @param num_of_processes: Number of processes to be initialized.
  *
  * Description: On a received signal from the generator, initializes processes, forks them,
  *              and adds them to the ready queue.
  */
-void initializeProcesses(int signum)
+static void initializeProcesses(int signum)
 {
     int msgQId = msgget(SHKEY, 0666 | IPC_CREAT);
     msgbuf_t msgbuf;
@@ -169,28 +167,188 @@ void initializeProcesses(int signum)
         process->start_time = -1;
         process->waiting_time = 0;
 
-        push(queue, (void *)process, 0);
+        enqueue(queue, (void *)process);
     }
 
     signal(SIGUSR1, initializeProcesses);
 }
 
-void generateProcesses()
+/**
+ * terminateRunningProcess - Terminates the currently running process
+ *
+ * @param signum: The signal number that triggered the termination.
+ *
+ * Description: Waits for the currently running process to terminate and then removes
+ *              it from the ready queue.
+ */
+static void terminateRunningProcess(int signum)
 {
-    if (!(*queue))
+    SchedulerConfig *schedulerConfig = getSchedulerConfigInstance();
+    scheduling_algo selected_algo = schedulerConfig->selected_algorithm;
+
+    int stat_loc;
+    PCB *process = popRunningProcess(selected_algo);
+    pid_t process_id = process->fork_id;
+
+    //printQueue(ready_queue);
+
+    wta_values = realloc(wta_values, sizeof(float) * total_processes);
+    if (wta_values == NULL)
+    {
+        perror("Can not resize the array of WTA values");
+        exit(EXIT_FAILURE);
+    }
+
+    wta_values[idx] = (float)(getClk() - process->arrival) / process->runtime;
+
+    total_waiting_time += process->waiting_time;
+    total_weighted_turnaround_time += wta_values[idx++];
+    total_running_time += process->runtime;
+
+    addFinishLog(logFile,
+                 getClk(),
+                 running_process->file_id,
+                 "finished",
+                 running_process->arrival,
+                 running_process->runtime,
+                 running_process->waiting_time,
+                 getClk() - running_process->arrival,
+                 (float)(getClk() - running_process->arrival) / running_process->runtime);
+
+    free(running_process);
+
+    running_process = NULL;
+
+    printf("Process %d Terminated at %d.\n", process_id, getClk());
+    //printQueue(ready_queue);
+
+    waitpid(process_id, &stat_loc, 0);
+    signal(SIGCHLD, terminateRunningProcess);
+}
+
+/**
+ * noMoreProcesses - Informs the scheduler that no more processes would be sent.
+ */
+static void noMoreProcesses(int signum)
+{
+    endScheduler = true;
+}
+
+/**
+ * clearResources - Deallocates resources used by the scheduler
+ * @param signum: The signal number
+ * 
+ * This function is a signal handler for cleaning up resources when SIGINT (Ctrl+C) is received.
+ * It deallocates the data structures used by the scheduler, closes opened files, and prints a message.
+ */
+static void clearResources(int signum)
+{
+    SchedulerConfig *schedulerConfig = getSchedulerConfigInstance();
+    scheduling_algo selected_algo = schedulerConfig->selected_algorithm;
+
+    // Deallocate the data structures
+    if (selected_algo == RR)
+        queue_free((queue_t *)ready_queue);
+    else
+        fib_heap_free((fib_heap_t *)ready_queue);
+    queue_free((queue_t *)queue);
+
+    // Close opened files
+    fclose(logFile);
+    fclose(perf);
+
+    printf("Cleared Scheduler Resources\n");
+}
+
+//=============================== SCHEDULER FUNCTIONS ===============================//
+
+/**
+ * allocateDataStructure - Allocates and returns a data structure based on the selected scheduling algorithm
+ * @param selected_algo: The selected scheduling algorithm (RR for Round Robin, others for other algorithms)
+ * @return A void pointer to the allocated data structure
+ *
+ * This function allocates a data structure based on the selected scheduling algorithm.
+ * For Round Robin (RR), it allocates a queue. For other algorithms, it allocates a Fibonacci heap.
+ */
+static void *allocateDataStructure(scheduling_algo selected_algo)
+{
+    if (selected_algo == RR)
+        return (void *)create_queue();
+    else
+        return (void *)fib_heap_alloc();
+}
+
+/**
+ * getRunningProcess - Retrieves the running process from the ready queue based on the selected algorithm
+ * @param selected_algo: The selected scheduling algorithm (RR for Round Robin, others for other algorithms)
+ * @return A pointer to the running process
+ *
+ * This function retrieves the running process from the ready queue based on the selected scheduling algorithm.
+ * For Round Robin (RR), it returns the front of the queue. For other algorithms, it returns the minimum element of the Fibonacci heap.
+ */
+static PCB *getRunningProcess(scheduling_algo selected_algo)
+{
+    if (selected_algo == RR)
+        return (PCB *)front((queue_t *)ready_queue);
+    else
+        return (PCB *)fib_heap_min((fib_heap_t *)ready_queue);
+}
+
+/**
+ * popRunningProcess - Removes and returns the running process from the ready queue based on the selected algorithm
+ * @param selected_algo: The selected scheduling algorithm (RR for Round Robin, others for other algorithms)
+ * @return A pointer to the removed running process
+ *
+ * This function removes and returns the running process from the ready queue based on the selected scheduling algorithm.
+ * For Round Robin (RR), it dequeues the front of the queue. For other algorithms, it extracts the minimum element of the Fibonacci heap.
+ */
+static PCB *popRunningProcess(scheduling_algo selected_algo)
+{
+    if (selected_algo == RR)
+        return (PCB *)dequeue((queue_t *)ready_queue);
+    else
+        return (PCB *)fib_heap_extract_min((fib_heap_t *)ready_queue);
+}
+
+/**
+ * is_running_queue_empty - Checks if the running queue is empty
+ * @param selected_algo: The selected scheduling algorithm
+ * @return 1 if the running queue is empty, otherwise 0
+ * 
+ * This function checks if the running queue is empty based on the selected scheduling algorithm.
+ */
+static short is_running_queue_empty(scheduling_algo selected_algo)
+{
+    if (selected_algo == RR)
+        return is_queue_empty((queue_t *)ready_queue);
+    else
+        return fib_heap_size((fib_heap_t *)ready_queue) == 0;
+}
+
+/**
+ * generateProcesses - Generates processes from the queue
+ *
+ * This function generates processes by forking and executing a program
+ * with arguments based on the information stored in the queue.
+ */
+static void generateProcesses()
+{
+    if (!queue)
         return;
     char *args[6];
+
+    // Get path to the process.out
     char absolute_path[PATH_SIZE];
     getAbsolutePath(absolute_path, "process.out");
+
+    // Initialize the args
     args[0] = absolute_path;
     args[5] = NULL; // Null-terminate the argument list
-    // Allocate memory for each string in args
     for (int i = 1; i < 5; i++)
         args[i] = (char *)malloc(12); // Assuming a 32-bit int can be at most 11 digits, plus 1 for null terminator
-    while ((*queue) != NULL)
+    while (!is_queue_empty(queue))
     {
-        PCB *process = (PCB *)((*queue)->process);
-        pop(queue);
+        PCB *process = (PCB *)dequeue(queue);
         sprintf(args[1], "%d", process->file_id);
         sprintf(args[2], "%d", process->arrival);
         sprintf(args[3], "%d", process->runtime);
@@ -210,71 +368,12 @@ void generateProcesses()
             exit(EXIT_FAILURE);
         }
         usleep(100 * 1000);
-
-        printf("Process %d Paused \n", pid);
         process->fork_id = pid;
         process->state = NEWBIE;
         addToReadyQueue(process);
     }
     for (int i = 1; i < 5; i++)
         free(args[i]);
-}
-
-void addFinishLog(FILE *file, int currentTime, int processId, char *state, int arrivalTime, int totalRuntime, int waitingTime, int TA, float WTA)
-{
-    fprintf(file, "At time %d process %d %s arr %d total %d remain %d wait %d TA %d WTA %.2f\n", currentTime, processId, state, arrivalTime, totalRuntime, 0, waitingTime, TA, WTA);
-}
-
-/**
- * terminateRunningProcess - Terminates the currently running process
- *
- * @param signum: The signal number that triggered the termination.
- *
- * Description: Waits for the currently running process to terminate and then removes
- *              it from the ready queue.
- */
-void terminateRunningProcess(int signum)
-{
-    pqueue_t **head = ready_queue;
-    int stat_loc;
-    pid_t process_id = ((PCB *)((*head)->process))->fork_id;
-
-    printQueue(ready_queue);
-
-    wta_values = realloc(wta_values, sizeof(float) * total_processes);
-    if (wta_values == NULL)
-    {
-        perror("Can not resize the array of WTA values");
-        exit(EXIT_FAILURE);
-    }
-
-    wta_values[idx] = (float)(getClk() - ((PCB *)((*head)->process))->arrival) / ((PCB *)((*head)->process))->runtime;
-
-    total_waiting_time += ((PCB *)((*head)->process))->waiting_time;
-    total_weighted_turnaround_time += wta_values[idx++];
-    total_running_time += ((PCB *)((*head)->process))->runtime;
-
-    pop(head);
-    ready_queue = head;
-    addFinishLog(logFile,
-                 getClk(),
-                 running_process->file_id,
-                 "finished",
-                 running_process->arrival,
-                 running_process->runtime,
-                 running_process->waiting_time,
-                 getClk() - running_process->arrival,
-                 (float)(getClk() - running_process->arrival) / running_process->runtime);
-
-    free(running_process);
-
-    running_process = NULL;
-
-    printf("Process %d Terminated at %d.\n", process_id, getClk());
-    printQueue(ready_queue);
-
-    waitpid(process_id, &stat_loc, 0);
-    signal(SIGCHLD, terminateRunningProcess);
 }
 
 /**
@@ -284,53 +383,92 @@ void terminateRunningProcess(int signum)
  *
  * Description: Adds a process to the ready queue based on the selected scheduling algorithm.
  */
-void addToReadyQueue(PCB *process)
+static void addToReadyQueue(PCB *process)
 {
-    pqueue_t **head = ready_queue;
     SchedulerConfig *schedulerConfig = getSchedulerConfigInstance();
     scheduling_algo selectedAlgorithm = schedulerConfig->selected_algorithm;
 
     switch (selectedAlgorithm)
     {
     case RR:
-        push(head, (void *)process, 0);
+        enqueue((queue_t *)ready_queue, (void *)process);
         break;
     case SRTN:
-        push(head, (void *)process, process->runtime);
+        fib_heap_insert((fib_heap_t *)ready_queue, (void *)process, process->runtime);
         break;
     case HPF:
-        if (*head == NULL)
-        {
-            push(head, (void *)process, process->priority);
-            break;
-        }
-        pqueue_t **temp_head = &((*head)->next);
-        push(temp_head, (void *)process, process->priority);
-        (*head)->next = *temp_head;
-        break;
+        fib_heap_insert((fib_heap_t *)ready_queue, (void *)process, process->priority);
     }
-    ready_queue = head;
+
     total_processes++;
 }
 
+//==================================== LOG DATA =====================================//
+
 /**
- * noMoreProcesses - Informs the scheduler that no more processes would be sent.
+ * calculate_std_wta - Calculates the standard deviation of weighted turnaround time (WTA)
+ * 
+ * This function calculates the standard deviation of WTA using the formula:
+ * standard deviation = sqrt((sum of squared differences from mean) / total_processes)
+ * 
+ * @return The standard deviation of WTA
  */
-void noMoreProcesses(int signum)
+static float calculate_std_wta()
 {
-    endScheduler = true;
+    float mean = total_weighted_turnaround_time / total_processes;
+    float sum = 0.0;
+    for (int i = 0; i < total_processes; i++)
+    {
+        sum += pow(wta_values[i] - mean, 2);
+    }
+    float variance = sum / total_processes;
+    return sqrt(variance);
 }
 
-void printQueue(pqueue_t **head)
+/**
+ * addPref - Adds performance metrics to a log file
+ * @param file: Pointer to the log file
+ * 
+ * This function adds CPU utilization, average WTA, average waiting time, and standard deviation of WTA
+ * to a log file.
+ */
+static void addPref(FILE *file)
 {
-    pqueue_t *temp = *head;
-    while (temp)
-    {
-        PCB *process = (PCB *)(temp->process);
-        printf("(%d, %d, %d)", process->file_id, process->priority, process->runtime);
-        if (temp->next)
-            printf("->");
-        temp = temp->next;
-    }
-    printf("\n");
+    fprintf(file, "CPU utilization = %.2f%%\n", (float)((total_running_time) / (float)getClk()) * 100.0);
+    fprintf(file, "Avg WTA = %.2f\n", total_weighted_turnaround_time / total_processes);
+    fprintf(file, "Avg Waiting = %.2f\n", total_waiting_time / total_processes);
+    fprintf(file, "STD WTA = %.2f\n", calculate_std_wta());
 }
+
+/**
+ * addFinishLog - Writes process finish information to a log file
+ * @param file: Pointer to the log file
+ * @param currentTime: The current time
+ * @param processId: The ID of the finished process
+ * @param state: The state of the finished process
+ * @param arrivalTime: The arrival time of the finished process
+ * @param totalRuntime: The total runtime of the finished process
+ * @param waitingTime: The waiting time of the finished process
+ * @param TA: The turnaround time of the finished process
+ * @param WTA: The weighted turnaround time of the finished process
+ * 
+ * This function writes process finish information to a log file in a specific format.
+ */
+static void addFinishLog(FILE *file, int currentTime, int processId, char *state, int arrivalTime, int totalRuntime, int waitingTime, int TA, float WTA)
+{
+    fprintf(file, "At time %d process %d %s arr %d total %d remain %d wait %d TA %d WTA %.2f\n", currentTime, processId, state, arrivalTime, totalRuntime, 0, waitingTime, TA, WTA);
+}
+
+// void printQueue(queue_t *head)
+// {
+//     queue_t *temp = *head;
+//     while (temp)
+//     {
+//         PCB *process = (PCB *)(temp->process);
+//         printf("(%d, %d, %d)", process->file_id, process->priority, process->runtime);
+//         if (temp->next)
+//             printf("->");
+//         temp = temp->next;
+//     }
+//     printf("\n");
+// }

--- a/src/test/queue_tester.c
+++ b/src/test/queue_tester.c
@@ -12,7 +12,7 @@ int main() {
   process2.priority = 2;
   process2.runtime = 70;
 
-  queue* my_queue = create_queue();
+  queue_t* my_queue = create_queue();
 
   enqueue(my_queue, &process1);
   enqueue(my_queue, &process2);

--- a/src/test/queue_tester.c
+++ b/src/test/queue_tester.c
@@ -12,7 +12,7 @@ int main() {
   process2.priority = 2;
   process2.runtime = 70;
 
-  queue_t* my_queue = create_queue();
+  queue* my_queue = create_queue();
 
   enqueue(my_queue, &process1);
   enqueue(my_queue, &process2);


### PR DESCRIPTION
## Docker
- Added `valgrind`.

## Makefile
- Updated dependencies.
- Run using `valgrind`.

## Scheduler
- Use queue for RR, Fib heap for SRTN & HPF.
- Clear Resources on simulation finish or termination.
- Fix SRTN context switch bug.